### PR TITLE
Fix https://github.com/Sprytile/Sprytile/issues/139

### DIFF
--- a/sprytile_gui.py
+++ b/sprytile_gui.py
@@ -486,10 +486,10 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
                     max(grid_pos.y, VIEW3D_OP_SprytileGui.sel_start.y)
                 ))
 
-                tilegrid.tile_selection[0] = sel_min.x
-                tilegrid.tile_selection[1] = sel_min.y
-                tilegrid.tile_selection[2] = (sel_max.x - sel_min.x) + 1
-                tilegrid.tile_selection[3] = (sel_max.y - sel_min.y) + 1
+                tilegrid.tile_selection[0] = int(sel_min.x)
+                tilegrid.tile_selection[1] = int(sel_min.y)
+                tilegrid.tile_selection[2] = int((sel_max.x - sel_min.x) + 1)
+                tilegrid.tile_selection[3] = int((sel_max.y - sel_min.y) + 1)
 
             do_release = event.type in {'LEFTMOUSE', 'MIDDLEMOUSE'} and event.value == 'RELEASE'
             if do_release and (VIEW3D_OP_SprytileGui.is_selecting or VIEW3D_OP_SprytileGui.is_moving):

--- a/sprytile_gui.py
+++ b/sprytile_gui.py
@@ -273,8 +273,8 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
         if is_snap_max_y:
             display_offset.y = display_max.y
         
-        context.scene.sprytile_ui.palette_pos[0] = display_offset.x
-        context.scene.sprytile_ui.palette_pos[1] = display_offset.y
+        context.scene.sprytile_ui.palette_pos[0] = int(display_offset.x)
+        context.scene.sprytile_ui.palette_pos[1] = int(display_offset.y)
 
     def calc_zoom(self, region, zoom, steps):
         if steps == 0:
@@ -472,8 +472,8 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
                     display_offset.y = max(display_offset.y, display_min.y)
                     display_offset.y = min(display_offset.y, display_max.y) 
                     
-                    context.scene.sprytile_ui.palette_pos[0] = display_offset.x
-                    context.scene.sprytile_ui.palette_pos[1] = display_offset.y
+                    context.scene.sprytile_ui.palette_pos[0] = int(display_offset.x)
+                    context.scene.sprytile_ui.palette_pos[1] = int(display_offset.y)
             # End tile palette movement code
 
             if VIEW3D_OP_SprytileGui.is_selecting:

--- a/sprytile_modal.py
+++ b/sprytile_modal.py
@@ -52,6 +52,8 @@ class VIEW3D_OP_SprytileModalTool(bpy.types.Operator):
         'FILL' : "Sprytile Fill Tool Map"
         }
 
+    draw_preview = False
+
     @staticmethod
     def calculate_view_axis(context):
         if context.area.type != 'VIEW_3D':


### PR DESCRIPTION
sel_min uses Blender's Vector which returns floats but tilegrid.tile_selection[#] expects int so an int is created when assigned in sprytile_gui.py

draw_preview can be used before modal in sprytile_modal.py so is initialized outside of modal()